### PR TITLE
Repair broken behavior due to Claude API changes

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-const CLAUDE_URL_PATTERN = /^https:\/\/claude\.ai\/api\/organizations\/[\w-]+\/chat_conversations\/[\w-]+\?tree=True.*?/;
+
+// Match only individual conversation endpoints (UUID path segment), not the /v2 listing.
+// The ?tree=True parameter requirement was removed because Anthropic may change query params;
+// a UUID-formatted path segment is sufficient to identify the right endpoint.
+const CLAUDE_URL_PATTERN = /^https:\/\/claude\.ai\/api\/organizations\/[\w-]+\/chat_conversations\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 
 chrome.webRequest.onBeforeRequest.addListener(
   function(details) {

--- a/popup.js
+++ b/popup.js
@@ -178,7 +178,10 @@ function buildMarkdown(parsed) {
         )})`
         );
         message.content.forEach((content) => {
-        if (content.type == "tool_use") {
+        if (content.type == "thinking") {
+            // Skip internal reasoning blocks — not part of the visible conversation.
+            return;
+        } else if (content.type == "tool_use") {
             if (content.name == "repl") {
             bits.push(
                 "**Analysis**\n```" +
@@ -202,24 +205,40 @@ function buildMarkdown(parsed) {
                 );
             }
             }
+            // Other tool_use types (web_search, web_fetch, etc.) are silently skipped —
+            // their results are tool infrastructure, not conversation content.
         } else if (content.type == "tool_result") {
-            if (content.name != "artifacts") {
-            let logs = JSON.parse(content.content[0].text).logs;
-            bits.push(
+            if (content.name == "repl") {
+            // Legacy analysis tool: result is JSON with a .logs array.
+            try {
+                let logs = JSON.parse(content.content[0].text).logs;
+                bits.push(
                 `**Result**\n<pre style="white-space: pre-wrap">\n${logs.join(
-                "\n"
+                    "\n"
                 )}\n</pre>`
+                );
+            } catch (e) {
+                // Ignore malformed repl results rather than crashing.
+            }
+            }
+            // All other tool results (web_search, web_fetch, artifacts, etc.) are skipped —
+            // they are raw data consumed by the model, not readable conversation text.
+        } else if (content.type == "text") {
+            if (content.text && content.text.trim()) {
+            bits.push(
+                replaceArtifactTags(
+                content.text.replace(/<\/antArtifact>/g, "\n```")
+                )
             );
             }
         } else {
+            // Unknown content type: surface it only if it carries a text field.
             if (content.text) {
             bits.push(
                 replaceArtifactTags(
                 content.text.replace(/<\/antArtifact>/g, "\n```")
                 )
             );
-            } else {
-            bits.push(JSON.stringify(content));
             }
         }
         });


### PR DESCRIPTION
# Fix blank popup caused by v2 endpoint interception and tool_result crash

Two bugs introduced by changes to the Claude.ai API were causing the popup to
render blank on every conversation load.

## Bug 1 — Wrong URL intercepted (`background.js`)

The URL filter regex matched `chat_conversations/v2` (the conversation listing
endpoint) in addition to individual conversation URLs. The `v2` path segment
satisfies `[\w-]+`, and `?tree=True` appears in both request types, so both
were intercepted. The listing response has no `chat_messages`, causing
`buildMarkdown` to return `""` immediately.

The fix requires a full UUID-format path segment
(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`), which the
`/v2` path can never satisfy. The `?tree=True` query-parameter requirement is
also dropped, since it is not needed to identify the correct endpoint and its
presence in the URL may change.

**Before:**
```js
const CLAUDE_URL_PATTERN = /^https:\/\/claude\.ai\/api\/organizations\/[\w-]+\/chat_conversations\/[\w-]+\?tree=True.*?/;
```

**After:**
```js
const CLAUDE_URL_PATTERN = /^https:\/\/claude\.ai\/api\/organizations\/[\w-]+\/chat_conversations\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
```

## Bug 2 — Uncaught exception in `buildMarkdown` (`popup.js`)

The `tool_result` handler assumed all non-artifact results came from the legacy
`repl` analysis tool and attempted `JSON.parse(content.content[0].text).logs`.
Modern Claude responses include tool results from `web_search`, `web_fetch`,
and other tools whose content is plain text, not a JSON object with a `.logs`
array. The parse threw an uncaught exception, preventing `textArea.value` from
ever being set.

Additionally, the new `thinking` content type fell through to the final
`else` branch, which called `JSON.stringify(content)` and dumped raw JSON into
the output.

The fixes:

- Narrow the `.logs` extraction path to `repl` results only, wrapped in
  `try/catch`.
- Skip all other `tool_result` types — they are raw data consumed by the model,
  not readable conversation content.
- Explicitly skip `thinking` blocks.
- Guard the final `else` branch to emit text only if a `text` field is present,
  rather than falling back to `JSON.stringify`.

## Installing a patched build locally

If you need a working version before this PR is merged, you can build and
side-load the extension directly from the `devstuff/fix-blank-popup` branch of the fork.

**Prerequisites:** `bash`, `zip`, `jq`

```bash
git clone --branch devstuff/fix-blank-popup https://github.com/devstuff/legoktm_claude-to-markdown.git
cd legoktm_claude-to-markdown
bash build.sh
```

This produces `../claude-to-markdown-<version>.zip`.

**Load in Firefox:**

1. Navigate to `about:debugging` → **This Firefox**.
2. Click **Load Temporary Add-on…**.
3. Select `manifest.json` inside the cloned directory.
4. The patched extension is now active for the current Firefox session.

> **Note:** Temporarily loaded extensions are removed when Firefox is closed.
> For a persistent installation that survives restarts, see the
> [`devstuff/personal` branch](https://github.com/devstuff/legoktm_claude-to-markdown/tree/devstuff/personal),
> which includes `publishing.md` — a step-by-step guide to signing the
> extension via Mozilla's AMO API and installing it permanently. That branch
> also carries personalised manifest changes (distinct gecko ID, version, and
> `homepage_url`) required to avoid conflicts with the upstream AMO listing when
> signing under a different Mozilla account.
